### PR TITLE
Start using insertion strings in event log messages

### DIFF
--- a/TailLight/device.cpp
+++ b/TailLight/device.cpp
@@ -233,7 +233,7 @@ Arguments:
     // Enforce safety limits (sets color to RED on failure)
     if (!packet->SafetyCheck()) {
         // log safety violation to Windows Event Viewer "System" log
-        WriteToSystemLog(Device, TailLight_SAFETY);
+        WriteToSystemLog(Device, TailLight_SAFETY, L"saturation");
         return STATUS_CONTENT_BLOCKED;
     }
 

--- a/TailLight/eventlog.h
+++ b/TailLight/eventlog.h
@@ -4,5 +4,6 @@
 #include "messages.h" // driver-specific MessageId values
 
 
-/** Write to the Windows Event Viewer "System" log. */
-void WriteToSystemLog(WDFDEVICE Device, NTSTATUS MessageId);
+/** Write to the Windows Event Viewer "System" log.
+    InsertionStr1 is a null-terminated string. */
+void WriteToSystemLog(WDFDEVICE Device, NTSTATUS MessageId, WCHAR* InsertionStr1);

--- a/TailLight/messages.mc
+++ b/TailLight/messages.mc
@@ -18,6 +18,6 @@ FacilityNames=(System=0x0
 
 MessageId=0x0001 Facility=Io Severity=Error SymbolicName=TailLight_SAFETY
 Language=English
-Color saturation exceeded safety threshold. Resetting color to RED to indicate failure.
+Color %2 exceeded safety threshold. Resetting color to RED to indicate failure.
 .
 ;#endif // __MESSAGES_H__


### PR DESCRIPTION
Done to enable more dynamic log messages.

```
// sizeof(IO_ERROR_LOG_PACKET) = 48
struct IO_ERROR_LOG_PACKET {
    UCHAR MajorFunctionCode;// 1 byte  (offset 0)
    UCHAR RetryCount;       // 1 byte  (offset 1)
    USHORT DumpDataSize;    // 2 bytes (offset 2)
    USHORT NumberOfStrings; // 2 bytes (offset 4)
    USHORT StringOffset;    // 2 bytes (offset 6)
    USHORT EventCategory;   // 2 bytes (offset 8)
                        // pad 2 bytes 
    NTSTATUS ErrorCode;     // 4 bytes (offset 12)
    ULONG UniqueErrorValue; // 4 bytes (offset 16)
    NTSTATUS FinalStatus;   // 4 bytes (offset 20)
    ULONG SequenceNumber;   // 4 bytes (offset 24)
    ULONG IoControlCode;    // 4 bytes (offset 28)
    LARGE_INTEGER DeviceOffset;// 8 bytes (offset 32)
    ULONG DumpData[1];      // 4 bytes (offset 40)
                        // pad 4 bytes
};
```
