### PR TITLE
Remove 100ms wait before turning tail-light off (leads to sporadic WdfIoTargetOpen errors)

### DIFF
--- a/TailLight/device.cpp
+++ b/TailLight/device.cpp
@@ -130,7 +130,7 @@ Arguments:
             return status;
         }
 
-        status = WdfTimerStart(timer, WDF_REL_TIMEOUT_IN_MS(100)); // wait 100ms
+        status = WdfTimerStart(timer, 0); // no wait
         if (!NT_SUCCESS(status)) {
             KdPrint(("WdfTimerStart failed 0x%x\n", status));
             return status;


### PR DESCRIPTION
PR to reproduce a problem. **Should not be merged** as-is.

Sporadic failure when attaching a mouse with this PR:
```
TailLight: DriverEntry - WDF version built on Jan 23 2024 02:06:24
TailLight: PdoName: \Device\000000cb
TailLight: EvtSetBlackTimer begin
TailLight: SetFeatureColor
TailLight: WdfIoTargetOpen failed 0xc000000e (STATUS_NO_SUCH_DEVICE)
TailLight: EvtSetBlackTimer failure NTSTATUS=0xc000000e
```