### PR TITLE
Private/bryan/periodic timer

### DIFF
--- a/TailLight/SetBlack.h
+++ b/TailLight/SetBlack.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define MAX_SET_BLACK_TIMER_TICKS 99
+
+VOID SetBlackTimerProc(WDFTIMER timer);

--- a/TailLight/SetBlack.h
+++ b/TailLight/SetBlack.h
@@ -3,3 +3,4 @@
 #define MAX_SET_BLACK_TIMER_TICKS 99
 
 VOID SetBlackTimerProc(WDFTIMER timer);
+NTSTATUS SetBlack_CreateRequest(WDFDEVICE device);

--- a/TailLight/SetBlack.h
+++ b/TailLight/SetBlack.h
@@ -3,4 +3,4 @@
 #define MAX_SET_BLACK_TIMER_TICKS 99
 
 VOID SetBlackTimerProc(WDFTIMER timer);
-NTSTATUS SetBlack_CreateRequest(WDFDEVICE device);
+NTSTATUS SetBlackAsync(WDFDEVICE device);

--- a/TailLight/SetTaillightBlack.cpp
+++ b/TailLight/SetTaillightBlack.cpp
@@ -1,0 +1,276 @@
+#include "driver.h"
+#include <Hidport.h>
+
+#include "debug.h"
+#include "SetBlack.h"
+
+// TODO: Streamline this once everything works
+
+EVT_WDF_REQUEST_COMPLETION_ROUTINE  EvtSetBlackCompletionRoutine;
+EVT_WDF_WORKITEM                    EvtSetBlackWorkItem;
+
+// TODO: Streamline this once everything works
+typedef struct _SET_BLACK_WORK_ITEM_CONTEXT {
+    WDFTIMER setBlackTimer;
+} SET_BLACK_WORK_ITEM_CONTEXT, * PSET_BLACK_WORK_ITEM_CONTEXT;
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(
+    SET_BLACK_WORK_ITEM_CONTEXT,
+    Get_SetBlackWorkItemContext)
+
+VOID SetBlackTimerProc(WDFTIMER timer) {
+
+    TRACE_FN_ENTRY
+    
+    PSET_BLACK_WORK_ITEM_CONTEXT pWorkItemContext = NULL;
+    WDFWORKITEM                  hWorkItem = 0;
+    NTSTATUS status = STATUS_PNP_DRIVER_CONFIGURATION_INCOMPLETE;
+
+    KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_TRACE_LEVEL, "TailLight: %s\n", __func__));
+
+    WDFDEVICE device = (WDFDEVICE)WdfTimerGetParentObject(timer);
+
+    {
+        WDF_WORKITEM_CONFIG        workItemConfig;
+        WDF_OBJECT_ATTRIBUTES      workItemAttributes;
+        WDF_OBJECT_ATTRIBUTES_INIT(&workItemAttributes);
+        workItemAttributes.ParentObject = device;
+        WDF_OBJECT_ATTRIBUTES_SET_CONTEXT_TYPE(&workItemAttributes,
+            SET_BLACK_WORK_ITEM_CONTEXT);
+
+        WDF_WORKITEM_CONFIG_INIT(&workItemConfig, EvtSetBlackWorkItem);
+
+        status = WdfWorkItemCreate(&workItemConfig,
+            &workItemAttributes,
+            &hWorkItem);
+
+        pWorkItemContext = Get_SetBlackWorkItemContext(hWorkItem);
+        pWorkItemContext->setBlackTimer = timer;
+
+        if (!NT_SUCCESS(status)) {
+            KdPrintEx((DPFLTR_IHVDRIVER_ID,
+                DPFLTR_ERROR_LEVEL,
+                "TailLight: Workitem creation failure 0x%x\n",
+                status));
+            return; // Maybe better luck next time.
+        }
+    }
+
+    WdfWorkItemEnqueue(hWorkItem);
+
+    TRACE_FN_EXIT
+}
+
+NTSTATUS SetBlack(
+    WDFDEVICE device)
+    /*++
+
+    Routine Description:
+
+        Attempts to set the taillight to the default state of black.
+
+    Arguments:
+
+        Device - Handle to a framework device object.
+
+    Return Value:
+
+        An NT or WDF status code.
+
+    --*/
+{
+    TailLightReport  report = {};
+    NTSTATUS         status = STATUS_FAILED_DRIVER_ENTRY;
+    WDFREQUEST       request = NULL;
+    WDFIOTARGET      hidTarget = NULL;
+
+    WDFMEMORY InBuffer = 0;
+    BOOLEAN ret = FALSE;
+    BYTE* pInBuffer = nullptr;
+    DEVICE_CONTEXT* pDeviceContext = NULL;
+
+    KdPrint(("TailLight: %s\n", __func__));
+
+    // Set up a WDF memory object for the IOCTL request
+    WDF_OBJECT_ATTRIBUTES mem_attrib = {};
+    WDF_OBJECT_ATTRIBUTES_INIT(&mem_attrib);
+
+    WDF_REQUEST_SEND_OPTIONS sendOptions = {};
+    WDF_REQUEST_SEND_OPTIONS_INIT(
+        &sendOptions,
+        WDF_REQUEST_SEND_OPTION_SYNCHRONOUS |
+        WDF_REQUEST_SEND_OPTION_TIMEOUT);
+    WDF_REQUEST_SEND_OPTIONS_SET_TIMEOUT(
+        &sendOptions,
+        WDF_REL_TIMEOUT_IN_SEC(1));
+
+    WDF_IO_TARGET_OPEN_PARAMS   openParams = {};
+
+    pDeviceContext =
+        WdfObjectGet_DEVICE_CONTEXT(device);
+
+    if (pDeviceContext == NULL) {
+        return STATUS_DEVICE_NOT_READY;
+    }
+
+    if (pDeviceContext->ulSetBlackTimerTicksLeft) {
+        pDeviceContext->ulSetBlackTimerTicksLeft--;
+    }
+    else
+    {
+        return STATUS_TIMEOUT;
+    }
+
+    status = WdfIoTargetCreate(
+        device,
+        WDF_NO_OBJECT_ATTRIBUTES,
+        &hidTarget);
+
+    if (!NT_SUCCESS(status)) {
+        KdPrintEx((DPFLTR_IHVDRIVER_ID,
+            DPFLTR_ERROR_LEVEL,
+            "TailLight: 0x%x while creating I/O target from worker thread\n",
+            status));
+        return status;
+    }
+
+    WDF_IO_TARGET_OPEN_PARAMS_INIT_OPEN_BY_NAME(
+        &openParams,
+        &pDeviceContext->PdoName,
+        FILE_WRITE_ACCESS);
+
+    openParams.Type = WDF_IO_TARGET_OPEN_TYPE::WdfIoTargetOpenByName;
+    openParams.ShareAccess = FILE_SHARE_WRITE | FILE_SHARE_READ;
+
+    status = WdfIoTargetOpen(hidTarget, &openParams);
+    if (!NT_SUCCESS(status)) {
+        KdPrintEx((DPFLTR_IHVDRIVER_ID,
+            DPFLTR_ERROR_LEVEL,
+            "TailLight: 0x%x while opening the I/O target from worker thread\n",
+            status));
+        goto ExitAndFree;
+    }
+
+    // TODO: Init to black once working.
+    report.Blue = 0xFF;
+    report.Green = 0xFF;
+    report.Red = 0xFF;
+
+    status = WdfRequestCreate(WDF_NO_OBJECT_ATTRIBUTES,
+        hidTarget,
+        &request);
+
+    if (!NT_SUCCESS(status)) {
+        KdPrint(("TailLight: WdfRequestCreate failed 0x%x\n", status));
+        goto ExitAndFree;
+    }
+
+    WdfRequestSetCompletionRoutine(
+        request,
+        EvtSetBlackCompletionRoutine,
+        WDF_NO_CONTEXT);
+
+    mem_attrib.ParentObject = request; // auto-delete with request
+
+    status = WdfMemoryCreate(&mem_attrib,
+        NonPagedPool,
+        POOL_TAG,
+        sizeof(TailLightReport),
+        &InBuffer,
+        (void**)&pInBuffer);
+
+    if (!NT_SUCCESS(status)) {
+        KdPrint(("TailLight: WdfMemoryCreate failed: 0x%x\n", status));
+        goto ExitAndFree;
+    }
+
+    // TODO: Wondering if we just cant cast pInBuffr as a TailLightReport
+    RtlCopyMemory(pInBuffer, &report, sizeof(TailLightReport));
+
+    // Format the request as write operation
+    status = WdfIoTargetFormatRequestForIoctl(hidTarget,
+        request,
+        IOCTL_HID_SET_FEATURE,
+        InBuffer,
+        NULL,
+        0,
+        0);
+
+    if (!NT_SUCCESS(status)) {
+        KdPrint(("TailLight: WdfIoTargetFormatRequestForIoctl failed: 0x%x\n", status));
+        goto ExitAndFree;
+    }
+
+    ret = WdfRequestSend(request,
+        hidTarget,
+        &sendOptions);
+
+    status = WdfRequestGetStatus(request);
+    KdPrint(("TailLight: %s WdfRequestSend status: 0x%x\n", __func__, status));
+
+ExitAndFree:
+    if (request != NULL) {
+        WdfObjectDelete(request);
+        request = NULL;
+    }
+
+    if (hidTarget != NULL) {
+        WdfObjectDelete(hidTarget);
+        hidTarget = NULL;
+    }
+        
+    return status;
+}
+
+
+VOID EvtQueryRelationsFilter(WDFDEVICE device, DEVICE_RELATION_TYPE RelationType)
+{
+    UNREFERENCED_PARAMETER(RelationType);
+    SetBlack(device);
+}
+
+void EvtSetBlackCompletionRoutine(
+    _In_ WDFREQUEST Request,
+    _In_ WDFIOTARGET Target,
+    _In_ PWDF_REQUEST_COMPLETION_PARAMS Params,
+    _In_ WDFCONTEXT Context)
+{
+    UNREFERENCED_PARAMETER(Request);
+    UNREFERENCED_PARAMETER(Target);
+    UNREFERENCED_PARAMETER(Params);
+    UNREFERENCED_PARAMETER(Context);
+}
+
+
+
+VOID EvtSetBlackWorkItem(
+    WDFWORKITEM workItem)
+    /*++
+
+    Routine Description:
+
+        Creates a WDF workitem to do the SetBlack() call after the driver
+        stack has initialized.
+
+    Arguments:
+
+        Device - Handle to a pre-allocated WDF work item.
+
+    Notes:
+        TODO: The framework might not be fully finished handling the PNP IRP
+        that launched this work item.
+    --*/
+{
+    TRACE_FN_ENTRY
+
+    PSET_BLACK_WORK_ITEM_CONTEXT pContext = Get_SetBlackWorkItemContext(workItem);
+    WDFDEVICE device = static_cast<WDFDEVICE>(WdfWorkItemGetParentObject(workItem));
+
+    NTSTATUS status = SetBlack(device);
+
+    if (NT_SUCCESS(status)) {
+        WdfTimerStop(pContext->setBlackTimer, FALSE);
+        pContext->setBlackTimer = NULL;
+    }
+
+    TRACE_FN_EXIT
+}

--- a/TailLight/SetTaillightBlack.cpp
+++ b/TailLight/SetTaillightBlack.cpp
@@ -6,8 +6,8 @@
 
 // TODO: Streamline this once everything works
 
-EVT_WDF_REQUEST_COMPLETION_ROUTINE  EvtSetBlackCompletionRoutine;
-EVT_WDF_WORKITEM                    EvtSetBlackWorkItem;
+EVT_WDF_REQUEST_COMPLETION_ROUTINE  SetBlackCompletionRoutine;
+EVT_WDF_WORKITEM                    SetBlackWorkItem;
 
 // TODO: Streamline this once everything works
 typedef struct _SET_BLACK_WORK_ITEM_CONTEXT {
@@ -37,7 +37,7 @@ VOID SetBlackTimerProc(WDFTIMER timer) {
         WDF_OBJECT_ATTRIBUTES_SET_CONTEXT_TYPE(&workItemAttributes,
             SET_BLACK_WORK_ITEM_CONTEXT);
 
-        WDF_WORKITEM_CONFIG_INIT(&workItemConfig, EvtSetBlackWorkItem);
+        WDF_WORKITEM_CONFIG_INIT(&workItemConfig, SetBlackWorkItem);
 
         status = WdfWorkItemCreate(&workItemConfig,
             &workItemAttributes,
@@ -186,7 +186,7 @@ VOID EvtQueryRelationsFilter(WDFDEVICE device, DEVICE_RELATION_TYPE RelationType
     SetBlack(device);
 }
 
-void EvtSetBlackCompletionRoutine(
+void SetBlackCompletionRoutine(
     _In_ WDFREQUEST Request,
     _In_ WDFIOTARGET Target,
     _In_ PWDF_REQUEST_COMPLETION_PARAMS Params,
@@ -199,7 +199,7 @@ void EvtSetBlackCompletionRoutine(
 }
 
 
-VOID EvtSetBlackWorkItem(
+VOID SetBlackWorkItem(
     WDFWORKITEM workItem)
     /*++
 
@@ -306,9 +306,9 @@ NTSTATUS SetBlack_CreateRequest(WDFDEVICE device) {
     }
 
     // TODO: Init to black once working.
-    report.Blue = 0xFF;
-    report.Green = 0xFF;
-    report.Red = 0xFF;
+    report.Blue = 0x0;
+    report.Green = 0x0;
+    report.Red = 0x0;
     
     status = WdfRequestCreate(WDF_NO_OBJECT_ATTRIBUTES,
         hidTarget,
@@ -321,7 +321,7 @@ NTSTATUS SetBlack_CreateRequest(WDFDEVICE device) {
 
     WdfRequestSetCompletionRoutine(
         request,
-        EvtSetBlackCompletionRoutine,
+        SetBlackCompletionRoutine,
         WDF_NO_CONTEXT);
 
     mem_attrib.ParentObject = request; // auto-delete with request*/

--- a/TailLight/TailLight.h
+++ b/TailLight/TailLight.h
@@ -23,7 +23,7 @@ struct TailLightReport {
         }
 
         if ((Unknown1 != 0xB2) || (Unknown2 != 0x03)) {
-            KdPrint(("TailLight: TailLightReport: Unknown control Code 0x%x 0x%x\n", Unknown1, Unknown2));
+            //KdPrint(("TailLight: TailLightReport: Unknown control Code 0x%x 0x%x\n", Unknown1, Unknown2));
             return false;
         }
 

--- a/TailLight/TailLight.vcxproj
+++ b/TailLight/TailLight.vcxproj
@@ -107,6 +107,7 @@ copy ..\IntelliMouse.ps1 $(OutDir)</Command>
     <ClCompile Include="device.cpp" />
     <ClCompile Include="driver.cpp" />
     <ClCompile Include="eventlog.cpp" />
+    <ClCompile Include="SetTaillightBlack.cpp" />
     <ClCompile Include="vfeature.cpp" />
     <ClCompile Include="wmi.cpp" />
     <ResourceCompile Include="module.rc" />
@@ -117,9 +118,11 @@ copy ..\IntelliMouse.ps1 $(OutDir)</Command>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CppAllocator.hpp" />
+    <ClInclude Include="debug.h" />
     <ClInclude Include="device.h" />
     <ClInclude Include="driver.h" />
     <ClInclude Include="eventlog.h" />
+    <ClInclude Include="SetBlack.h" />
     <ClInclude Include="TailLight.h" />
     <ClInclude Include="vfeature.h" />
     <ClInclude Include="wmi.h" />

--- a/TailLight/debug.h
+++ b/TailLight/debug.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#pragma once
+
+#define TRACE_FN_ENTRY KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_TRACE_LEVEL, "TailLight: Entry %s\n", __func__));
+#define TRACE_FN_EXIT  KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_TRACE_LEVEL, "TailLight: Exit: %s\n", __func__));
+#define TRACE_REQUEST_BOOL(ret)  KdPrint(("TailLight: WdfRequestSend returned bool: 0x%x\n", ret));
+#define TRACE_REQUEST_FAILURE(status)  KdPrint(("TailLight: WdfRequestSend failed. Status=: 0x%x\n", ret));
+
+NTSTATUS DumpTarget(WDFIOTARGET target, WDFMEMORY& memory);

--- a/TailLight/device.cpp
+++ b/TailLight/device.cpp
@@ -92,7 +92,7 @@ NTSTATUS PnpNotifyDeviceInterfaceChange(
     _In_ PVOID pvNotificationStructure,
     _Inout_opt_ PVOID pvContext) {
 
-    KdPrint(("TailLight: PnpNotifyDeviceInterfaceChange enter\n"));
+    //KdPrint(("TailLight: PnpNotifyDeviceInterfaceChange enter\n"));
     ASSERTMSG("WDFDEVICE not passed in!", pvContext);
 
     if (pvNotificationStructure == NULL) {
@@ -108,6 +108,8 @@ NTSTATUS PnpNotifyDeviceInterfaceChange(
     if (IsEqualGUID(*(LPGUID) & (pDevInterface->Event),
         *(LPGUID)&GUID_DEVICE_INTERFACE_ARRIVAL)) {
 
+        // We don't care about removal or query removes.
+        // If the Pro Intellimouse is removed it goes black, so no work needed.
         auto& symLinkName = pDevInterface->SymbolicLinkName;
         if (symLinkName->Length < sizeof(MSINTELLIMOUSE_USBINTERFACE5_PREFIX)) {
             return STATUS_SUCCESS;
@@ -118,12 +120,11 @@ NTSTATUS PnpNotifyDeviceInterfaceChange(
             symLinkName->Buffer,
             sizeof(MSINTELLIMOUSE_USBINTERFACE5_PREFIX) - 2)) {
 
-            // TODO:
-            // Queue work item
-            // See stuff on page 356 of Oney
+            // Opening a device may trigger PnP operations. Ensure that either a
+            // timer or a work item is used when opening up a device.
+            // Refer to p356 of Oney and IoGetDeviceObjectPointer.
             return StartTimerToOpenDevice((WDFDEVICE)pvContext);
         }
-
     }
 
     return STATUS_SUCCESS;

--- a/TailLight/device.h
+++ b/TailLight/device.h
@@ -5,6 +5,7 @@ typedef struct _DEVICE_CONTEXT {
     UNICODE_STRING PdoName;
     ULONG          TailLight; ///< last written color
     ULONG          ulSetBlackTimerTicksLeft;
+    PDEVICE_OBJECT pdo;
 } DEVICE_CONTEXT;
 
 WDF_DECLARE_CONTEXT_TYPE(DEVICE_CONTEXT)

--- a/TailLight/device.h
+++ b/TailLight/device.h
@@ -4,6 +4,7 @@
 typedef struct _DEVICE_CONTEXT {
     UNICODE_STRING PdoName;
     ULONG          TailLight; ///< last written color
+    ULONG          ulSetBlackTimerTicksLeft;
 } DEVICE_CONTEXT;
 
 WDF_DECLARE_CONTEXT_TYPE(DEVICE_CONTEXT)

--- a/TailLight/device.h
+++ b/TailLight/device.h
@@ -10,6 +10,21 @@ typedef struct _DEVICE_CONTEXT {
     PDEVICE_OBJECT pdo;
 } DEVICE_CONTEXT;
 
+#define NUKE_WDF_HANDLE( h ) { \
+    WdfObjectDelete(h);  \
+    h = NULL; }
+
+template<typename T> inline void NukeWdfHandle(T& handle) {
+    if (!handle) {
+        WdfObjectDelete(handle);
+        handle = 0;
+    }
+}
+
+#define RETURN_RESULT_IF_SET_OPERATION_NULL( var, op, result ) { \
+    var = op; \
+    if (var == NULL) return status; }
+
 WDF_DECLARE_CONTEXT_TYPE(DEVICE_CONTEXT)
 
 WDF_DECLARE_CONTEXT_TYPE(TailLightDeviceInformation)

--- a/TailLight/device.h
+++ b/TailLight/device.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define MSINTELLIMOUSE_USBINTERFACE5_PREFIX L"\\??\\HID#VID_045E&PID_082A&MI_01&Col05"
+
 /** Driver-specific struct for storing instance-specific data. */
 typedef struct _DEVICE_CONTEXT {
     UNICODE_STRING PdoName;
@@ -13,3 +15,7 @@ WDF_DECLARE_CONTEXT_TYPE(DEVICE_CONTEXT)
 WDF_DECLARE_CONTEXT_TYPE(TailLightDeviceInformation)
 
 EVT_WDF_DEVICE_CONTEXT_CLEANUP EvtDeviceContextCleanup;
+
+NTSTATUS PnpNotifyDeviceInterfaceChange(
+    _In_ PVOID NotificationStructure,
+    _Inout_opt_ PVOID Context);

--- a/TailLight/driver.h
+++ b/TailLight/driver.h
@@ -14,7 +14,14 @@
 
 
 /** Memory allocation tag name (for debugging leaks). */
-static constexpr ULONG POOL_TAG = 'ffly';
+static constexpr ULONG POOL_TAG = 'ylff';
+static constexpr ULONG WDF_POOL_TAG = 'wTLT'; // Taillight WPF allocated
+
+typedef struct _DRIVER_CONTEXT {
+    PVOID pnpDevInterfaceChangedHandle;
+} DRIVER_CONTEXT, * PDRIVER_CONTEXT;
+
+WDF_DECLARE_CONTEXT_TYPE(DRIVER_CONTEXT);
 
 extern "C"
 DRIVER_INITIALIZE         DriverEntry;

--- a/TailLight/vfeature.cpp
+++ b/TailLight/vfeature.cpp
@@ -191,11 +191,11 @@ Arguments:
     Request - Pointer to Request Packet.
 --*/
 {
-    KdPrint(("TailLight: SetFeatureFilter\n"));
+    //KdPrint(("TailLight: SetFeatureFilter\n"));
     DEVICE_CONTEXT* deviceContext = WdfObjectGet_DEVICE_CONTEXT(Device);
 
     if (InputBufferLength != sizeof(TailLightReport)) {
-        KdPrint(("TailLight: SetFeatureFilter: Incorrect InputBufferLength\n"));
+        //KdPrint(("TailLight: SetFeatureFilter: Incorrect InputBufferLength\n"));
         return STATUS_BUFFER_TOO_SMALL;
     }
 


### PR DESCRIPTION
1. Defer to device arrival using IoRegisterPlugPlayNotification.
2. Deadlock scenario if we try to open the device within a PnP IRP, so need to use a timer or work item. Using timer code for now.
3. Opening a device is dependent on ZwCreateFile(). There is always a chance it can fail, so we need a restart mechanism.
4. The synchronous base SetBlack() code broke for some reason. Since SetBlackAsync() works, let's validate that we can open the device reliably and use what works.
5. I left the create handler in case we need to serialize it in order to make WdfIoTargetOpen more reliable. But if validation shows that we don't need to synchronize it then we can get rid of it.