### PR TITLE
Add WMI instance to device context

### DIFF
--- a/TailLight/device.h
+++ b/TailLight/device.h
@@ -3,7 +3,7 @@
 /** Driver-specific struct for storing instance-specific data. */
 typedef struct _DEVICE_CONTEXT {
     UNICODE_STRING PdoName;
-    ULONG          TailLight; ///< last written color
+    WDFWMIINSTANCE WmiInstance;
 } DEVICE_CONTEXT;
 
 WDF_DECLARE_CONTEXT_TYPE(DEVICE_CONTEXT)

--- a/TailLight/vfeature.cpp
+++ b/TailLight/vfeature.cpp
@@ -228,7 +228,8 @@ Arguments:
     }
 
     // update last written color
-    deviceContext->TailLight = packet->GetColor();
+    TailLightDeviceInformation* pInfo = WdfObjectGet_TailLightDeviceInformation(deviceContext->WmiInstance);
+    pInfo->TailLight = packet->GetColor();
 
     return status;
 }


### PR DESCRIPTION
Done to avoid duplicating WMI state like `TailLight` in the device context. Also, remove initial `TailLight` clearing in `WmiInitialize`, since WDF is automatically clearing all context objects.