### PR TITLE
Switch to using PnpUtil for driver installation

### DIFF
--- a/MouseMirror/INSTALL_MouseMirror.bat
+++ b/MouseMirror/INSTALL_MouseMirror.bat
@@ -2,11 +2,11 @@
 :: Goto current directory
 cd /d "%~dp0"
 
-:: Use DevCon for installation, since it allows providing HWID
-devcon /r install MouseMirror.inf "HID\VID_045E&PID_082A&MI_00&Col01"
+:: Install certificate for silent driver installation and loading (run from administative developer command prompt)
+:: certmgr.exe /add MouseMirror.cer /s /r localMachine root
+:: certmgr.exe /add MouseMirror.cer /s /r localMachine trustedpublisher
 
-:: Use PnpUtil for installation (succeeds but driver isn't loaded)
-::devgen /add /bus ROOT /hardwareid "HID\VID_045E&PID_082A&MI_00&Col01"
-::PNPUTIL /add-driver MouseMirror.inf /install /reboot
+:: Use PnpUtil for installation
+PNPUTIL /add-driver MouseMirror.inf /install /reboot
 
 pause

--- a/MouseMirror/MouseMirror.vcxproj
+++ b/MouseMirror/MouseMirror.vcxproj
@@ -75,7 +75,6 @@
     </DriverSign>
     <PostBuildEvent>
       <Command>copy *.bat $(PackageDir)
-copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x64\dev*.exe" $(PackageDir)
 copy ..\MouseMirror.ps1 $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -99,7 +98,6 @@ copy ..\MouseMirror.ps1 $(OutDir)</Command>
     </DriverSign>
     <PostBuildEvent>
       <Command>copy *.bat $(PackageDir)
-copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x64\dev*.exe" $(PackageDir)
 copy ..\MouseMirror.ps1 $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/MouseMirror/UNINSTALL_MouseMirror.bat
+++ b/MouseMirror/UNINSTALL_MouseMirror.bat
@@ -2,11 +2,6 @@
 :: Goto current directory
 cd /d "%~dp0"
 
-:: delete the devnode
-devcon /r remove "HID\VID_045E&PID_082A&MI_00&Col01"
-:: TODO: Switch to PNPUTIL in Win11 21H2
-::PNPUTIL /remove-device /deviceid "HID\VID_045E&PID_082A&MI_00&Col01"
-
 :: uninstall driver
 PNPUTIL /delete-driver MouseMirror.inf /uninstall /force /reboot
 

--- a/TailLight/INSTALL_TailLight.bat
+++ b/TailLight/INSTALL_TailLight.bat
@@ -2,11 +2,11 @@
 :: Goto current directory
 cd /d "%~dp0"
 
-:: Use DevCon for installation, since it allows providing HWID
-devcon /r install TailLight.inf "HID\VID_045E&PID_082A&MI_01&Col05"
+:: Install certificate for silent driver installation and loading (run from administative developer command prompt)
+:: certmgr.exe /add TailLight.cer /s /r localMachine root
+:: certmgr.exe /add TailLight.cer /s /r localMachine trustedpublisher
 
-:: Use PnpUtil for installation (succeeds but driver isn't loaded)
-::devgen /add /bus ROOT /hardwareid "HID\VID_045E&PID_082A&MI_01&Col05"
-::PNPUTIL /add-driver TailLight.inf /install /reboot
+:: Use PnpUtil for installation
+PNPUTIL /add-driver TailLight.inf /install /reboot
 
 pause

--- a/TailLight/TailLight.vcxproj
+++ b/TailLight/TailLight.vcxproj
@@ -75,7 +75,6 @@
     </DriverSign>
     <PostBuildEvent>
       <Command>copy *.bat $(PackageDir)
-copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x64\dev*.exe" $(PackageDir)
 copy ..\TailLight.ps1 $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -99,7 +98,6 @@ copy ..\TailLight.ps1 $(OutDir)</Command>
     </DriverSign>
     <PostBuildEvent>
       <Command>copy *.bat $(PackageDir)
-copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x64\dev*.exe" $(PackageDir)
 copy ..\TailLight.ps1 $(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/TailLight/UNINSTALL_TailLight.bat
+++ b/TailLight/UNINSTALL_TailLight.bat
@@ -2,11 +2,6 @@
 :: Goto current directory
 cd /d "%~dp0"
 
-:: delete the devnode
-devcon /r remove "HID\VID_045E&PID_082A&MI_01&Col05"
-:: TODO: Switch to PNPUTIL in Win11 21H2
-::PNPUTIL /remove-device /deviceid "HID\VID_045E&PID_082A&MI_01&Col05"
-
 :: uninstall driver
 PNPUTIL /delete-driver TailLight.inf /uninstall /force /reboot
 


### PR DESCRIPTION
Done to get rid of the DevCon dependency to fix #17.

Based on the last commit in #52 with some simplifications.

## Certificate installation
This require the certificate used for driver signing to be installed to the `root` and `trustedpublisher` stores in order for the driver to be auto-loaded as documented on https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/certmgr

Example of certificate installation:  
![image](https://github.com/forderud/IntelliMouseDriver/assets/2671400/3dc75cca-76d2-4d85-9fef-10e0cad64df4)
![image](https://github.com/forderud/IntelliMouseDriver/assets/2671400/503da01d-e15b-4ca5-9a48-377980744589)
