### PR TITLE
TailLight: Use "TaLi" tag also for framework allocations

### DIFF
--- a/MouseMirror/driver.cpp
+++ b/MouseMirror/driver.cpp
@@ -11,6 +11,7 @@ NTSTATUS DriverEntry(
 
     WDF_DRIVER_CONFIG params = {};
     WDF_DRIVER_CONFIG_INIT(/*out*/&params, EvtDriverDeviceAdd);
+    params.DriverPoolTag = POOL_TAG;
     params.EvtDriverUnload = EvtDriverUnload;
 
     // Create the framework WDFDRIVER object, with the handle to it returned in Driver.

--- a/MouseMirror/driver.h
+++ b/MouseMirror/driver.h
@@ -11,6 +11,8 @@
 #include "device.h"
 #include "wmi.h"
 
+/** Memory allocation tag name (for debugging leaks). */
+static constexpr ULONG POOL_TAG = 'iMoM'; // displayed as "MoMi"
 
 extern "C"
 DRIVER_INITIALIZE         DriverEntry;

--- a/TailLight/driver.cpp
+++ b/TailLight/driver.cpp
@@ -11,6 +11,7 @@ NTSTATUS DriverEntry(
 
     WDF_DRIVER_CONFIG params = {};
     WDF_DRIVER_CONFIG_INIT(/*out*/&params, EvtDriverDeviceAdd);
+    params.DriverPoolTag = POOL_TAG;
     params.EvtDriverUnload = EvtDriverUnload;
 
     // Create the framework WDFDRIVER object, with the handle to it returned in Driver.


### PR DESCRIPTION
Also, start using "MoMi" tag for MouseMirror driver allocations by WDF.