### PR TITLE
TailLight: Switch to getting properties from I/O target instead of device

### DIFF
--- a/TailLight/device.cpp
+++ b/TailLight/device.cpp
@@ -46,15 +46,15 @@ NTSTATUS EvtSelfManagedIoInit(WDFDEVICE device) {
 }
 
 
-static UNICODE_STRING GetDevicePropertyString(WDFDEVICE device, DEVICE_REGISTRY_PROPERTY DeviceProperty) {
+static UNICODE_STRING GetTargetPropertyString(WDFIOTARGET target, DEVICE_REGISTRY_PROPERTY DeviceProperty) {
     WDF_OBJECT_ATTRIBUTES attributes = {};
     WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
-    attributes.ParentObject = device; // auto-delete with device
+    attributes.ParentObject = target; // auto-delete with I/O target
 
     WDFMEMORY memory = 0;
-    NTSTATUS status = WdfDeviceAllocAndQueryProperty(device, DeviceProperty, NonPagedPoolNx, &attributes, &memory);
+    NTSTATUS status = WdfIoTargetAllocAndQueryTargetProperty(target, DeviceProperty, NonPagedPoolNx, &attributes, &memory);
     if (!NT_SUCCESS(status)) {
-        KdPrint(("TailLight: WdfDeviceAllocAndQueryProperty with property=0x%x failed 0x%x\n", DeviceProperty, status));
+        KdPrint(("TailLight: WdfIoTargetAllocAndQueryTargetProperty with property=0x%x failed 0x%x\n", DeviceProperty, status));
         return {};
     }
 
@@ -115,7 +115,7 @@ Arguments:
 
     {
         // initialize DEVICE_CONTEXT struct with PdoName
-        deviceContext->PdoName = GetDevicePropertyString(device, DevicePropertyPhysicalDeviceObjectName);
+        deviceContext->PdoName = GetTargetPropertyString(WdfDeviceGetIoTarget(device), DevicePropertyPhysicalDeviceObjectName);
         if (!deviceContext->PdoName.Buffer) {
             KdPrint(("TailLight: PdoName query failed\n"));
             return STATUS_UNSUCCESSFUL;
@@ -125,7 +125,7 @@ Arguments:
     }
     {
         // initialize DEVICE_CONTEXT struct with HardwareId
-        deviceContext->HardwareId = GetDevicePropertyString(device, DevicePropertyHardwareID);
+        deviceContext->HardwareId = GetTargetPropertyString(WdfDeviceGetIoTarget(device), DevicePropertyHardwareID);
         if (!deviceContext->HardwareId.Buffer) {
             KdPrint(("TailLight: HardwareId query failed\n"));
             return STATUS_UNSUCCESSFUL;


### PR DESCRIPTION
Use `WdfDeviceGetIoTarget(device)` to get the default I/O target for the device that shares the same lifetime as the device. Done to more easily get the HWID also from I/O targets in a later PR.

WinDBG output when connecting the mouse:
```
TailLight: DriverEntry - WDF version built on Mar 11 2024 02:14:34
TailLight: PdoName: \Device\000000b9
TailLight: HardwareId: HID\VID_045E&PID_082A&REV_0095&MI_01&Col05
...
```

This shows that the driver still functions as before, and is still able to retrieve the PDO name and HWID.