### PR TITLE
TailLight: Implement WMI self-test method

### DIFF
--- a/TailLight.ps1
+++ b/TailLight.ps1
@@ -15,3 +15,6 @@ Write-Host("  Changing color to {0:x}" -f $mouse.TailLight) # display as hex str
 
 Write-Host("Storing changes.")
 Set-CimInstance -CimInstance $mouse
+
+
+Invoke-CimMethod -InputObject $mouse -MethodName SelfTest

--- a/TailLight/TailLight.mof
+++ b/TailLight/TailLight.mof
@@ -18,4 +18,7 @@ class TailLightDeviceInformation {
 
     [WmiDataId(1), read, write, Description("Tail-light in RGB COLORREF format.")]
     uint32 TailLight;
+
+    [WmiMethodId(1), Implemented, Description("Trigger HW self-test")]
+    void SelfTest();
 };

--- a/TailLight/device.h
+++ b/TailLight/device.h
@@ -4,6 +4,7 @@
 struct DEVICE_CONTEXT {
     UNICODE_STRING PdoName;
     WDFWMIINSTANCE WmiInstance;
+    WDFTIMER       SelfTestTimer;
 };
 WDF_DECLARE_CONTEXT_TYPE(DEVICE_CONTEXT)
 

--- a/TailLight/wmi.h
+++ b/TailLight/wmi.h
@@ -1,6 +1,26 @@
 // Where they are described.
 #define MOFRESOURCENAME L"TailLightWMI"
 
+/** Self-test context that counts down until completion. */
+struct SELF_TEST_CONTEXT {
+    ULONG State = 0;
+
+    bool IsBusy() const {
+        return (State != 0);
+    }
+
+    void Start() {
+        State = 16;
+    }
+
+    bool Advance() {
+        State -= 1;
+        return (State != 0);
+    }
+};
+
+WDF_DECLARE_CONTEXT_TYPE(SELF_TEST_CONTEXT);
+
 // Initialize WMI provider
 NTSTATUS WmiInitialize(_In_ WDFDEVICE Device);
 


### PR DESCRIPTION
Cleaned up version of #70. Done to demonstrate how HW self-tests can be exposed through WMI interfaces.