### PR TITLE
VirtualMouse: Delete unused PnP callbacks

### DIFF
--- a/VirtualMouse/Device.cpp
+++ b/VirtualMouse/Device.cpp
@@ -42,12 +42,8 @@ Arguments:
 
 	WDF_PNPPOWER_EVENT_CALLBACKS wdfPnpPowerCallbacks = {};
 	WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&wdfPnpPowerCallbacks);
-	wdfPnpPowerCallbacks.EvtDevicePrepareHardware = ControllerWdfEvtDevicePrepareHardware;
-	wdfPnpPowerCallbacks.EvtDeviceReleaseHardware = ControllerWdfEvtDeviceReleaseHardware;
 	wdfPnpPowerCallbacks.EvtDeviceD0Entry = ControllerWdfEvtDeviceD0Entry;
 	wdfPnpPowerCallbacks.EvtDeviceD0Exit = ControllerWdfEvtDeviceD0Exit;
-	wdfPnpPowerCallbacks.EvtDeviceD0EntryPostInterruptsEnabled = ControllerWdfEvtDeviceD0EntryPostInterruptsEnabled;
-	wdfPnpPowerCallbacks.EvtDeviceD0ExitPreInterruptsDisabled = ControllerWdfEvtDeviceD0ExitPreInterruptsDisabled;
 
 	WdfDeviceInitSetPnpPowerEventCallbacks(WdfDeviceInit, &wdfPnpPowerCallbacks);
 
@@ -272,25 +268,6 @@ exit:
 
 
 NTSTATUS
-ControllerWdfEvtDevicePrepareHardware(
-	_In_
-	WDFDEVICE       WdfDevice,
-	_In_
-	WDFCMRESLIST    WdfResourcesRaw,
-	_In_
-	WDFCMRESLIST    WdfResourcesTranslated
-)
-{
-	FuncEntry(TRACE_DEVICE);
-	UNREFERENCED_PARAMETER(WdfDevice);
-	UNREFERENCED_PARAMETER(WdfResourcesRaw);
-	UNREFERENCED_PARAMETER(WdfResourcesTranslated);
-	FuncExit(TRACE_DEVICE, 0);
-	return STATUS_SUCCESS;
-}
-
-
-NTSTATUS
 ControllerWdfEvtDeviceD0Entry(
 	_In_
 	WDFDEVICE              WdfDevice,
@@ -320,38 +297,6 @@ exit:
 
 
 NTSTATUS
-ControllerWdfEvtDeviceD0EntryPostInterruptsEnabled(
-	_In_
-	WDFDEVICE              WdfDevice,
-	_In_
-	WDF_POWER_DEVICE_STATE PreviousState
-)
-{
-	FuncEntry(TRACE_DEVICE);
-	UNREFERENCED_PARAMETER(WdfDevice);
-	UNREFERENCED_PARAMETER(PreviousState);
-	FuncExit(TRACE_DEVICE, 0);
-	return STATUS_SUCCESS;
-}
-
-
-NTSTATUS
-ControllerWdfEvtDeviceD0ExitPreInterruptsDisabled(
-	_In_
-	WDFDEVICE              WdfDevice,
-	_In_
-	WDF_POWER_DEVICE_STATE TargetState
-)
-{
-	FuncEntry(TRACE_DEVICE);
-	UNREFERENCED_PARAMETER(WdfDevice);
-	UNREFERENCED_PARAMETER(TargetState);
-	FuncExit(TRACE_DEVICE, 0);
-	return STATUS_SUCCESS;
-}
-
-
-NTSTATUS
 ControllerWdfEvtDeviceD0Exit(
 	_In_ WDFDEVICE              WdfDevice,
 	_In_ WDF_POWER_DEVICE_STATE TargetState
@@ -363,23 +308,6 @@ ControllerWdfEvtDeviceD0Exit(
 		Usb_Disconnect(WdfDevice);
 	}
 
-	FuncExit(TRACE_DEVICE, 0);
-	return STATUS_SUCCESS;
-}
-
-
-
-NTSTATUS
-ControllerWdfEvtDeviceReleaseHardware(
-	_In_
-	WDFDEVICE       WdfDevice,
-	_In_
-	WDFCMRESLIST    WdfResourcesTranslated
-)
-{
-	FuncEntry(TRACE_DEVICE);
-	UNREFERENCED_PARAMETER(WdfDevice);
-	UNREFERENCED_PARAMETER(WdfResourcesTranslated);
 	FuncExit(TRACE_DEVICE, 0);
 	return STATUS_SUCCESS;
 }

--- a/VirtualMouse/Device.h
+++ b/VirtualMouse/Device.h
@@ -48,12 +48,8 @@ UDEFX2CreateDevice(
     );
 
 
-EVT_WDF_DEVICE_PREPARE_HARDWARE                 ControllerWdfEvtDevicePrepareHardware;
-EVT_WDF_DEVICE_RELEASE_HARDWARE                 ControllerWdfEvtDeviceReleaseHardware;
 EVT_WDF_DEVICE_D0_ENTRY                         ControllerWdfEvtDeviceD0Entry;
 EVT_WDF_DEVICE_D0_EXIT                          ControllerWdfEvtDeviceD0Exit;
-EVT_WDF_DEVICE_D0_ENTRY_POST_INTERRUPTS_ENABLED ControllerWdfEvtDeviceD0EntryPostInterruptsEnabled;
-EVT_WDF_DEVICE_D0_EXIT_PRE_INTERRUPTS_DISABLED  ControllerWdfEvtDeviceD0ExitPreInterruptsDisabled;
 EVT_WDF_OBJECT_CONTEXT_CLEANUP                  ControllerWdfEvtCleanupCallback;
 EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL              ControllerEvtIoDeviceControl;
 


### PR DESCRIPTION
Delete do-nothing callbacks related to HW prepare/release and interrupt enable/disable. Done to get rid of unnecessary complexity.