### PR TITLE
Extend WMI SelfTest method with return value

### DIFF
--- a/TailLight.ps1
+++ b/TailLight.ps1
@@ -16,5 +16,7 @@ Write-Host("  Changing color to {0:x}" -f $mouse.TailLight) # display as hex str
 Write-Host("Storing changes.")
 Set-CimInstance -CimInstance $mouse
 
-
-Invoke-CimMethod -InputObject $mouse -MethodName SelfTest
+Write-Host("Running HW self-test...")
+$res = Invoke-CimMethod -InputObject $mouse -MethodName SelfTest
+Write-Host("  result: {0}" -f $res.result)
+Write-Host("  ReturnValue: {0}" -f $res.ReturnValue)

--- a/TailLight/TailLight.mof
+++ b/TailLight/TailLight.mof
@@ -20,5 +20,5 @@ class TailLightDeviceInformation {
     uint32 TailLight;
 
     [WmiMethodId(1), Implemented, Description("Trigger HW self-test")]
-    void SelfTest();
+    void SelfTest([out] sint32 result);
 };

--- a/TailLight/device.cpp
+++ b/TailLight/device.cpp
@@ -145,6 +145,8 @@ Arguments:
         return status;
     }
 
+    KeInitializeEvent(&deviceContext->SelfTestCompleted, SynchronizationEvent, FALSE);
+
     return status;
 }
 

--- a/TailLight/device.h
+++ b/TailLight/device.h
@@ -5,6 +5,7 @@ struct DEVICE_CONTEXT {
     UNICODE_STRING PdoName;
     WDFWMIINSTANCE WmiInstance;
     WDFTIMER       SelfTestTimer;
+    KEVENT         SelfTestCompleted;
 };
 WDF_DECLARE_CONTEXT_TYPE(DEVICE_CONTEXT)
 

--- a/TailLight/wmi.h
+++ b/TailLight/wmi.h
@@ -3,7 +3,8 @@
 
 /** Self-test context that counts down until completion. */
 struct SELF_TEST_CONTEXT {
-    ULONG State = 0;
+    NTSTATUS Result = STATUS_UNSUCCESSFUL;
+    ULONG    State = 0;
 
     bool IsBusy() const {
         return (State != 0);


### PR DESCRIPTION
Use a `KEVENT` to signal that the self-test have either completed or been aborted. Cleaned up version of #76 with some small adjustments.