### PR TITLE
TailLight: Replace input.inf with MsHidKmdf.inf as dependency

### DIFF
--- a/TailLight/TailLight.inx
+++ b/TailLight/TailLight.inx
@@ -33,13 +33,13 @@ TailLight.sys = 1
 
 ; Install Section
 [TailLight_Inst.NT]
-Include = input.INF
-Needs = HID_Raw_Inst.NT
+Include=MsHidKmdf.inf
+Needs=MsHidKmdf.NT
 CopyFiles = @TailLight.sys
 
 [TailLight_Inst.NT.HW]
-Include = input.INF
-Needs = HID_Raw_Inst.NT.Hw
+Include=MsHidKmdf.inf
+Needs=MsHidKmdf.NT.HW
 
 [TailLight_Inst.NT.Filters]
 ; https://learn.microsoft.com/en-us/windows-hardware/drivers/install/inf-addfilter-directive
@@ -49,8 +49,8 @@ AddFilter = TailLight, , UpperFilter_Inst
 FilterPosition = Upper
 
 [TailLight_Inst.NT.Services]
-Include = input.INF
-Needs = HID_Raw_Inst.NT.Services
+Include=MsHidKmdf.inf
+Needs=MsHidKmdf.NT.Services
 AddService = TailLight, , TailLight_Service_Inst, TailLight_EventLog_Inst
 
 [TailLight_Service_Inst]


### PR DESCRIPTION
Cleanup to stay in sync with https://github.com/microsoft/Windows-driver-samples/blob/main/hid/vhidmini2/driver/kmdf/vhidmini.inx . This file claims that MsHidKmdf.inf was introduced in Win11 build 22000, but the driver still works fine when testing on Win10 22H2.