### PR TITLE
TailLight: Remove unused MsHidKmdf depdendency

### DIFF
--- a/TailLight/TailLight.inx
+++ b/TailLight/TailLight.inx
@@ -33,13 +33,9 @@ TailLight.sys = 1
 
 ; Install Section
 [TailLight_Inst.NT]
-Include=MsHidKmdf.inf
-Needs=MsHidKmdf.NT
 CopyFiles = @TailLight.sys
 
 [TailLight_Inst.NT.HW]
-Include=MsHidKmdf.inf
-Needs=MsHidKmdf.NT.HW
 
 [TailLight_Inst.NT.Filters]
 ; https://learn.microsoft.com/en-us/windows-hardware/drivers/install/inf-addfilter-directive
@@ -49,9 +45,8 @@ AddFilter = TailLight, , UpperFilter_Inst
 FilterPosition = Upper
 
 [TailLight_Inst.NT.Services]
-Include=MsHidKmdf.inf
-Needs=MsHidKmdf.NT.Services
 AddService = TailLight, , TailLight_Service_Inst, TailLight_EventLog_Inst
+AddService = ,2
 
 [TailLight_Service_Inst]
 DisplayName   = "IntelliMouse TailLight filter driver"


### PR DESCRIPTION
Follow-up to #84.
Add `AddService = ,2` as work-around for the following error:
`error 1296: Hardware 'IntelliMouse TailLight filter driver' does not have an associated service using install section 'TailLight_Inst.NT'.`

Based on documentation on: https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/inf-validation-errors-and-warnings