### PR TITLE
Don't store full PDB path in binaries

### DIFF
--- a/MouseMirror/MouseMirror.vcxproj
+++ b/MouseMirror/MouseMirror.vcxproj
@@ -87,7 +87,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -101,7 +101,7 @@ copy $(OutDir)\MouseMirror.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -115,7 +115,7 @@ copy $(OutDir)\MouseMirror.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -129,7 +129,7 @@ copy $(OutDir)\MouseMirror.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>

--- a/TailLight/TailLight.vcxproj
+++ b/TailLight/TailLight.vcxproj
@@ -87,7 +87,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -101,7 +101,7 @@ copy $(OutDir)\TailLight.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -115,7 +115,7 @@ copy $(OutDir)\TailLight.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -129,7 +129,7 @@ copy $(OutDir)\TailLight.cer $(PackageDir)</Command>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(DDK_LIB_PATH)\hidparse.lib</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>

--- a/VirtualMouse/VirtualMouse.vcxproj
+++ b/VirtualMouse/VirtualMouse.vcxproj
@@ -100,7 +100,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)\ude\1.0\udecxstub.lib;usbdex.lib;WdmSec.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -122,7 +122,7 @@ copy *.bat $(PackageDir)</Command>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)\ude\1.0\udecxstub.lib;usbdex.lib;WdmSec.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -144,7 +144,7 @@ copy *.bat $(PackageDir)</Command>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)\ude\1.0\udecxstub.lib;usbdex.lib;WdmSec.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -166,7 +166,7 @@ copy *.bat $(PackageDir)</Command>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)\ude\1.0\udecxstub.lib;usbdex.lib;WdmSec.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/brepro /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>


### PR DESCRIPTION
Follow-up to #94. Done to make the binaries more reproducible. Based on suggestions on https://nikhilism.com/post/2020/windows-deterministic-builds/

Please note that the cryptographic signature may still differ between builds if using a time server or different signatures. This is expected and can be worked around by removing the signatures with `signtool.exe remove /s <driver>.sys` before comparing.

Visual diff of generated binaries:  
![image](https://github.com/user-attachments/assets/c4e14211-8039-4a45-acbd-8b70574d96ab)
